### PR TITLE
Add MinIO support

### DIFF
--- a/base-local/docker-compose.yaml.minio
+++ b/base-local/docker-compose.yaml.minio
@@ -22,6 +22,7 @@ x-app: &default-app
     - "AWS_REGION=${AWS_REGION}"
     - "AWS_S3_USER=${AWS_S3_USER}"
     - "AWS_S3_KEY=${AWS_S3_KEY}"
+    - "AWS_S3_SECRET=${AWS_S3_SECRET}"
 
 services:
   database:
@@ -99,8 +100,8 @@ services:
   minio:
     image: minio/minio
     environment:
-      - "MINIO_ACCESS_KEY=${AWS_S3_USER}"
-      - "MINIO_SECRET_KEY=${AWS_S3_KEY}"
+      - "MINIO_ACCESS_KEY=${AWS_S3_KEY}"
+      - "MINIO_SECRET_KEY=${AWS_S3_SECRET}"
     ports:
       - "9000:9000"
     command: ["server", "/data"]

--- a/base-local/docker-compose.yaml.minio
+++ b/base-local/docker-compose.yaml.minio
@@ -1,0 +1,111 @@
+version: "3.6"
+
+x-app: &default-app
+  environment:
+    - "READIUM_DATABASE_HOST=${READIUM_DATABASE_HOST}"
+    - "READIUM_DATABASE_PORT=${READIUM_DATABASE_PORT}"
+    - "READIUM_DATABASE_USERNAME=${READIUM_DATABASE_USERNAME}"
+    - "READIUM_DATABASE_PASSWORD=${READIUM_DATABASE_PASSWORD}"
+    - "READIUM_LCPSERVER_HOST=http://${READIUM_LCPSERVER_HOST}:${READIUM_LCPSERVER_PORT}"
+    - "READIUM_LCPSERVER_PORT=${READIUM_LCPSERVER_PORT}"
+    - "READIUM_LCPSERVER_DATABASE=${READIUM_LCPSERVER_DATABASE}"
+    - "READIUM_LCPSERVER_USERNAME=${READIUM_LCPSERVER_USERNAME}"
+    - "READIUM_LCPSERVER_PASSWORD=${READIUM_LCPSERVER_PASSWORD}"
+    - "READIUM_LSDSERVER_HOST=http://${READIUM_LSDSERVER_HOST}:${READIUM_LSDSERVER_PORT}"
+    - "READIUM_LSDSERVER_PORT=${READIUM_LSDSERVER_PORT}"
+    - "READIUM_LSDSERVER_DATABASE=${READIUM_LSDSERVER_DATABASE}"
+    - "READIUM_FRONTEND_HOST=http://${READIUM_FRONTEND_HOST}:${READIUM_FRONTEND_PORT}"
+    - "READIUM_FRONTEND_PORT=${READIUM_FRONTEND_PORT}"
+    - "READIUM_FRONTEND_DATABASE=${READIUM_FRONTEND_DATABASE}"
+    - "READIUM_ENC_CONTENT=/opt/readium/files/encrypted"
+    - "READIUM_CONTENT_S3_BUCKET=${READIUM_CONTENT_S3_BUCKET}"
+    - "AWS_REGION=${AWS_REGION}"
+    - "AWS_S3_USER=${AWS_S3_USER}"
+    - "AWS_S3_KEY=${AWS_S3_KEY}"
+
+services:
+  database:
+    build: ./database
+    image: database
+    ports:
+      - "${READIUM_DATABASE_EXTERNAL_PORT}:${READIUM_DATABASE_PORT}"
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: "${READIUM_DATABASE_PASSWORD}"
+    volumes:
+      - "dbdata:/var/lib/mysql"
+
+  sftp:
+    image: "atmoz/sftp:alpine"
+    ports:
+      - "${READIUM_SFTP_EXTERNAL_PORT}:${READIUM_SFTP_PORT}"
+    volumes:
+      - "./files/users.conf:/etc/sftp/users.conf:ro"
+      - "rawfiles:/home"
+
+  lcpencrypt:
+    <<: *default-app
+    image: "readium/lcpencrypt:working"
+    build:
+      context: .
+      target: "lcpencrypt"
+    volumes:
+      - "encfiles:/opt/readium/files/encrypted"
+      - "rawfiles:/opt/readium/files/raw"
+
+  lcpserver:
+    <<: *default-app
+    image: "readium/lcpserver:working"
+    build:
+      context: .
+      target: "lcpserver"
+    ports:
+      - "${READIUM_LCPSERVER_EXTERNAL_PORT}:${READIUM_LCPSERVER_PORT}"
+    volumes:
+      - "encfiles:/opt/readium/files/encrypted"
+      - "./etc:/etc/readium"
+    depends_on:
+      - database
+      - minio
+
+  lsdserver:
+    <<: *default-app
+    image: "readium/lsdserver:working"
+    build:
+      context: .
+      target: "lsdserver"
+    ports:
+      - "${READIUM_LSDSERVER_EXTERNAL_PORT}:${READIUM_LSDSERVER_PORT}"
+    volumes:
+      - "./etc:/etc/readium"
+    depends_on:
+      - database
+
+  testfrontend:
+    <<: *default-app
+    image: "readium/testfrontend:working"
+    build:
+      context: .
+      target: "testfrontend"
+    ports:
+      - "${READIUM_FRONTEND_EXTERNAL_PORT}:${READIUM_FRONTEND_PORT}"
+    volumes:
+      - "encfiles:/opt/readium/files/encrypted"
+      - "rawfiles:/opt/readium/files/raw"
+      - "./etc:/etc/readium"
+    depends_on:
+      - database
+
+  minio:
+    image: minio/minio
+    environment:
+      - "MINIO_ACCESS_KEY=${AWS_S3_USER}"
+      - "MINIO_SECRET_KEY=${AWS_S3_KEY}"
+    ports:
+      - "9000:9000"
+    command: ["server", "/data"]
+
+volumes:
+  encfiles:
+  dbdata:
+  rawfiles:

--- a/base-local/etc/config.yaml.minio
+++ b/base-local/etc/config.yaml.minio
@@ -1,0 +1,74 @@
+# Configuration Settings for LCP servers
+# Shared configuration, all services in one file
+# Encrypted Resource type:
+#   * TODO: S3 bucket: publicly accessible folder for simple
+#     development environment (not production) -- needs work
+
+# The usernames and passwords must match the ones in the htpasswd files for each server.
+
+lcp_update_auth:
+  username: "${READIUM_LCPSERVER_USERNAME}"
+  password: "${READIUM_LCPSERVER_PASSWORD}"
+
+lsd_notify_auth:
+  username: "${READIUM_LCPSERVER_USERNAME}"
+  password: "${READIUM_LCPSERVER_PASSWORD}"
+
+# LCP Server
+
+profile: "basic"
+lcp:
+  host: "0.0.0.0"
+  port: ${READIUM_LCPSERVER_PORT}
+  public_base_url: "${READIUM_LCPSERVER_HOST}"
+  database: "mysql://${READIUM_DATABASE_USERNAME}:${READIUM_DATABASE_PASSWORD}@tcp(${READIUM_DATABASE_HOST}:${READIUM_DATABASE_PORT})/${READIUM_LCPSERVER_DATABASE}?parseTime=true"
+  auth_file: "/etc/readium/htpasswd"
+storage:
+  mode: "s3"
+  endpoint: http://minio:9000
+  bucket: "${READIUM_CONTENT_S3_BUCKET}"
+  region: "${AWS_REGION}"
+  access_id: "${AWS_S3_USER}"
+  secret: "${AWS_S3_KEY}"
+  disable_ssl: true
+  path_style: true
+  token:
+certificate:
+  cert: "/etc/readium/certificate.pub"
+  private_key: "/etc/readium/certificate.pem"
+license:
+  links:
+    status: "${READIUM_LSDSERVER_HOST}/licenses/{license_id}/status"
+    hint: "${READIUM_FRONTEND_HOST}/static/hint.html"
+    publication: "${READIUM_LCPSERVER_HOST}/contents/{publication_id}"
+
+
+# LSD Server
+
+lsd:
+  host: "0.0.0.0"
+  port: ${READIUM_LSDSERVER_PORT}
+  public_base_url: "${READIUM_LSDSERVER_HOST}"
+  database: "mysql://${READIUM_DATABASE_USERNAME}:${READIUM_DATABASE_PASSWORD}@tcp(${READIUM_DATABASE_HOST}:${READIUM_DATABASE_PORT})/${READIUM_LSDSERVER_DATABASE}?parseTime=true"
+  auth_file: "/etc/readium/htpasswd"
+  license_link_url: "${READIUM_FRONTEND_HOST}/api/v1/licenses/{license_id}"
+license_status:
+  register: true
+  renew: true
+  return: true
+  renting_days: 60
+  renew_days: 7
+
+
+# Frontend Server
+
+frontend:
+  host: "0.0.0.0"
+  port: ${READIUM_FRONTEND_PORT}
+  public_base_url: "${READIUM_FRONTEND_HOST}"
+  database: "mysql://${READIUM_DATABASE_USERNAME}:${READIUM_DATABASE_PASSWORD}@tcp(${READIUM_DATABASE_HOST}:${READIUM_DATABASE_PORT})/${READIUM_FRONTEND_DATABASE}?parseTime=true"
+  master_repository: "/opt/readium/files/raw/frontend/uploads"
+  encrypted_repository: "$READIUM_ENC_CONTENT"
+  provider_uri: "https://www.myprovider.org"
+  right_print: 10
+  right_copy: 2000

--- a/base-local/etc/config.yaml.minio
+++ b/base-local/etc/config.yaml.minio
@@ -28,8 +28,8 @@ storage:
   endpoint: http://minio:9000
   bucket: "${READIUM_CONTENT_S3_BUCKET}"
   region: "${AWS_REGION}"
-  access_id: "${AWS_S3_USER}"
-  secret: "${AWS_S3_KEY}"
+  access_id: "${AWS_S3_KEY}"
+  secret: "${AWS_S3_SECRET}"
   disable_ssl: true
   path_style: true
   token:


### PR DESCRIPTION
This PR adds support for [MinIO](https://min.io/), S3-compatible storage that can be run locally and used for integration tests.
The PR includes 2 new files:
- `docker-compose.yaml.minio` contains a definition of MinIO service running in the same network as `lcpserver`
- `etc/config.yaml.minio` contains additional settings required for successful connection of `lcpencrypt` to `minio
   - `endpoint` declares that AWS S3 SDK should use `http://minio:9000` as S3 endpoint
   - `path_style` indicating that AWS S3 SDK should use old path-style requests, otherwise it would've used virtual-hosted style requests (i.e. http://bucket.minio:9000) which would've required adjusting DNS settings 
   - `disable_ssl` indicating that AWS S3 SDK should use plain HTTP requests
   - `token` indicating that MTS token should be empty