### PR TITLE
Fix publication URLs

### DIFF
--- a/base-local/etc/config.yaml.minio
+++ b/base-local/etc/config.yaml.minio
@@ -40,7 +40,7 @@ license:
   links:
     status: "${READIUM_LSDSERVER_HOST}/licenses/{license_id}/status"
     hint: "${READIUM_FRONTEND_HOST}/static/hint.html"
-    publication: "${READIUM_LCPSERVER_HOST}/contents/{publication_id}"
+    publication: "http://minio:9000/${READIUM_CONTENT_S3_BUCKET}/publication_id}"
 
 
 # LSD Server

--- a/base-local/etc/config.yaml.s3
+++ b/base-local/etc/config.yaml.s3
@@ -36,7 +36,7 @@ license:
   links:
     status: "${READIUM_LSDSERVER_HOST}/licenses/{license_id}/status"
     hint: "${READIUM_FRONTEND_HOST}/static/hint.html"
-    publication: "${READIUM_LCPSERVER_HOST}/contents/{publication_id}"
+    publication: "https://${READIUM_CONTENT_S3_BUCKET}.s3.${AWS_REGION}.amazonaws.com/{publication_id}"
 
 
 # LSD Server


### PR DESCRIPTION
This PR fixes publication URLs in cofig.yaml.* files. Encrypted books should be served from S3/MinIO not the LCP License Server.